### PR TITLE
Feature improve

### DIFF
--- a/android-support/skin-support/src/main/java/skin/support/SkinCompatManager.java
+++ b/android-support/skin-support/src/main/java/skin/support/SkinCompatManager.java
@@ -9,8 +9,10 @@ import android.content.res.ColorStateList;
 import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import android.text.TextUtils;
 import android.util.SparseArray;
 
@@ -43,6 +45,7 @@ public class SkinCompatManager extends SkinObservable {
     private List<SkinLayoutInflater> mHookInflaters = new ArrayList<>();
     private SparseArray<SkinLoaderStrategy> mStrategyMap = new SparseArray<>();
     private boolean mSkinAllActivityEnable = true;
+    private boolean mSkinSomeActivityDisable = false;
     private boolean mSkinStatusBarColorEnable = false;
     private boolean mSkinWindowBackgroundColorEnable = true;
 
@@ -267,6 +270,23 @@ public class SkinCompatManager extends SkinObservable {
 
     public boolean isSkinAllActivityEnable() {
         return mSkinAllActivityEnable;
+    }
+
+    public boolean isSkinSomeActivityDisable() {
+        return mSkinSomeActivityDisable;
+    }
+
+    /**
+     * 设置是否部分Activity不换肤
+     *
+     * @param enable true:实现{@link skin.support.annotation.Skindisable}的activity不换肤；
+     *               false:不再检查{@link skin.support.annotation.Skindisable}
+     *               def:false
+     * @return
+     */
+    public SkinCompatManager setSkinSomeActivityDisable(boolean enable) {
+        this.mSkinSomeActivityDisable = enable;
+        return this;
     }
 
     @Deprecated

--- a/android-support/skin-support/src/main/java/skin/support/annotation/Skindisable.java
+++ b/android-support/skin-support/src/main/java/skin/support/annotation/Skindisable.java
@@ -1,0 +1,12 @@
+package skin.support.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({TYPE})
+public @interface Skindisable {
+}

--- a/android-support/skin-support/src/main/java/skin/support/app/SkinActivityLifecycle.java
+++ b/android-support/skin-support/src/main/java/skin/support/app/SkinActivityLifecycle.java
@@ -14,6 +14,7 @@ import java.util.WeakHashMap;
 import androidx.core.view.LayoutInflaterCompat;
 import skin.support.SkinCompatManager;
 import skin.support.annotation.Skinable;
+import skin.support.annotation.Skindisable;
 import skin.support.content.res.SkinCompatResources;
 import skin.support.observe.SkinObservable;
 import skin.support.observe.SkinObserver;
@@ -150,6 +151,12 @@ public class SkinActivityLifecycle implements Application.ActivityLifecycleCallb
     }
 
     private boolean isContextSkinEnable(Context context) {
+        if (SkinCompatManager.getInstance().isSkinSomeActivityDisable()) {
+            if (context.getClass().getAnnotation(Skindisable.class) != null) {
+                return false;
+            }
+        }
+
         return SkinCompatManager.getInstance().isSkinAllActivityEnable()
                 || context.getClass().getAnnotation(Skinable.class) != null
                 || context instanceof SkinCompatSupportable;

--- a/android-support/skin-support/src/main/java/skin/support/content/res/SkinCompatResources.java
+++ b/android-support/skin-support/src/main/java/skin/support/content/res/SkinCompatResources.java
@@ -105,7 +105,7 @@ public class SkinCompatResources {
         return getColorStateList(SkinCompatManager.getInstance().getContext(), resId);
     }
 
-    int getTargetResId(Context context, int resId) {
+    public int getTargetResId(Context context, int resId) {
         try {
             String resName = null;
             if (mStrategy != null) {

--- a/demo/skin-app/src/main/AndroidManifest.xml
+++ b/demo/skin-app/src/main/AndroidManifest.xml
@@ -50,6 +50,10 @@
             android:label="Test Activity"
             android:theme="@style/AppTheme" />
         <activity
+            android:name="com.ximsfei.skindemo.test.SkindisableTestActivity"
+            android:label="Skindisable Activity"
+            android:theme="@style/AppTheme" />
+        <activity
             android:name="com.ximsfei.skindemo.actionbar.ActionbarTestActivity"
             android:screenOrientation="portrait"
             android:theme="@style/ActionbarTheme" />

--- a/demo/skin-app/src/main/java/com/ximsfei/skindemo/App.java
+++ b/demo/skin-app/src/main/java/com/ximsfei/skindemo/App.java
@@ -1,6 +1,7 @@
 package com.ximsfei.skindemo;
 
 import android.app.Application;
+
 import androidx.appcompat.app.AppCompatDelegate;
 
 import com.ximsfei.skindemo.loader.CustomSDCardLoader;
@@ -42,8 +43,9 @@ public class App extends Application {
                 .addInflater(new SkinCircleImageViewInflater()) // hdodenhof/CircleImageView
                 .addInflater(new SkinFlycoTabLayoutInflater())  // H07000223/FlycoTabLayout
                 .setSkinStatusBarColorEnable(true)              // 关闭状态栏换肤
-//                .setSkinWindowBackgroundEnable(false)           // 关闭windowBackground换肤
-//                .setSkinAllActivityEnable(false)                // true: 默认所有的Activity都换肤; false: 只有实现SkinCompatSupportable接口的Activity换肤
+//               .setSkinWindowBackgroundEnable(false)           // 关闭windowBackground换肤
+//               .setSkinAllActivityEnable(false)                // true: 默认所有的Activity都换肤; false: 只有实现SkinCompatSupportable接口的Activity换肤
+                .setSkinSomeActivityDisable(true)                //true:实现{@link skin.support.annotation.Skindisable}的activity不换肤；false:不再检查{@link skin.support.annotation.Skindisable}；def:false
                 .loadSkin();
         AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
     }

--- a/demo/skin-app/src/main/java/com/ximsfei/skindemo/SplashActivity.java
+++ b/demo/skin-app/src/main/java/com/ximsfei/skindemo/SplashActivity.java
@@ -5,7 +5,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Color;
 import android.os.Bundle;
+
 import androidx.annotation.Nullable;
+
 import android.util.DisplayMetrics;
 import android.util.TypedValue;
 import android.view.Gravity;
@@ -25,6 +27,7 @@ import com.ximsfei.skindemo.flycotablayout.ui.SimpleHomeActivity;
 import com.ximsfei.skindemo.mdtab.MaterialDesignActivity;
 import com.ximsfei.skindemo.picker.DrawablePickerActivity;
 import com.ximsfei.skindemo.tab.MainActivity;
+import com.ximsfei.skindemo.test.SkindisableTestActivity;
 import com.ximsfei.skindemo.test.TestActivity;
 import com.ximsfei.skindemo.window.WindowManagerActivity;
 import com.ximsfei.skindemo.zip.ZipActivity;
@@ -44,6 +47,7 @@ public class SplashActivity extends BaseActivity {
             "AlertDialog",
             "WindowManager",
             "Test",
+            "SkindisableTest",
             "Actionbar",
             "Color Picker",
             "Drawable Picker",
@@ -57,6 +61,7 @@ public class SplashActivity extends BaseActivity {
             AlertDialogActivity.class,
             WindowManagerActivity.class,
             TestActivity.class,
+            SkindisableTestActivity.class,
             ActionbarTestActivity.class,
             ColorPickerActivity.class,
             DrawablePickerActivity.class,

--- a/demo/skin-app/src/main/java/com/ximsfei/skindemo/test/SkindisableTestActivity.java
+++ b/demo/skin-app/src/main/java/com/ximsfei/skindemo/test/SkindisableTestActivity.java
@@ -1,0 +1,14 @@
+package com.ximsfei.skindemo.test;
+
+import android.os.Bundle;
+
+import androidx.annotation.Nullable;
+import skin.support.annotation.Skindisable;
+
+@Skindisable
+public class SkindisableTestActivity extends TestActivity {
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+}


### PR DESCRIPTION
1. 添加注解@Skindisable支持设置部分页面不换肤；添加测试@Skindisable的页面：SkindisableTestActivity。 原因：大部分页面都需要换肤，这个时候就没必要再加注解Skinable，而是针对不需要换肤的加上不需要换肤的注解。
2. 开放SkinCompatResources#getTargetResId(Context context, int resId),允许用户直接获取对应资源的资源id。  原因：在实际应用中有获取资源文件id的需求，在换肤模式中会自动拼接换肤资源的后缀。比如获取图片、drawable等的资源id等。